### PR TITLE
Fix hbase script syntax error

### DIFF
--- a/hbase_script.py
+++ b/hbase_script.py
@@ -1,12 +1,9 @@
 import happybase
-import pandas as pd
-from collections import Counter
-from datetime import datetime
-import time
 import csv
 
-#Paso 1: Cargar csv
-hbase thrift start
+# Asegúrate de iniciar el servidor Thrift de HBase por separado
+# antes de ejecutar este script. Ejemplo:
+#   hbase thrift start
 
 # Conexión a HBase vía Thrift (puerto 9090 por defecto)
 connection = happybase.Connection('localhost', port=9090)


### PR DESCRIPTION
## Summary
- remove inline 'hbase thrift start' command causing syntax error
- add instructions for starting the HBase Thrift server before running the script

## Testing
- `python -m py_compile hbase_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894fcbefc2c83228101dcccb4f34b9b