### PR TITLE
fix: update hbase image and drop compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mongo:
     image: mongo:latest
@@ -14,7 +12,7 @@ services:
       - "6379:6379"
 
   hbase:
-    image: harisekhon/hbase:2.4
+    image: harisekhon/hbase:latest
     container_name: hbase
     ports:
       - "16010:16010"  # Web UI


### PR DESCRIPTION
## Summary
- remove obsolete compose file version field
- use existing Harisekhon HBase image tag

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895081e27608322935fba2329247eea